### PR TITLE
Add AuthContext for fake authentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,20 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo-google-fonts/dm-sans": "^0.3.0",
+        "@react-native-async-storage/async-storage": "^1.24.0",
         "@react-native-community/datetimepicker": "8.3.0",
         "@react-navigation/bottom-tabs": "^7.3.14",
         "@react-navigation/native": "^7.1.9",
         "@react-navigation/native-stack": "^7.3.13",
+        "@types/uuid": "^10.0.0",
         "expo": "~53.0.9",
         "expo-constants": "^17.1.6",
         "expo-dev-client": "~5.2.0",
         "expo-font": "~13.3.1",
+        "expo-image-manipulator": "~13.1.7",
         "expo-image-picker": "~16.1.4",
         "expo-linear-gradient": "~14.1.4",
+        "expo-sharing": "~13.1.5",
         "expo-status-bar": "~2.2.3",
         "expo-updates": "~0.28.13",
         "firebase": "^11.8.1",
@@ -29,7 +33,8 @@
         "react-native-reanimated": "~3.17.4",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1",
-        "react-native-svg": "15.11.2"
+        "react-native-svg": "15.11.2",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -2121,6 +2126,17 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@expo/ngrok/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
     },
     "node_modules/@expo/osascript": {
       "version": "2.2.4",
@@ -4329,6 +4345,18 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.24.0.tgz",
+      "integrity": "sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.60 <1.0"
+      }
+    },
     "node_modules/@react-native-community/datetimepicker": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-8.3.0.tgz",
@@ -5131,6 +5159,12 @@
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -8203,6 +8237,18 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-image-manipulator": {
+      "version": "13.1.7",
+      "resolved": "https://registry.npmjs.org/expo-image-manipulator/-/expo-image-manipulator-13.1.7.tgz",
+      "integrity": "sha512-DBy/Xdd0E/yFind14x36XmwfWuUxOHI/oH97/giKjjPaRc2dlyjQ3tuW3x699hX6gAs9Sixj5WEJ1qNf3c8sag==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~5.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-image-picker": {
       "version": "16.1.4",
       "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-16.1.4.tgz",
@@ -8280,6 +8326,15 @@
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"
+      }
+    },
+    "node_modules/expo-sharing": {
+      "version": "13.1.5",
+      "resolved": "https://registry.npmjs.org/expo-sharing/-/expo-sharing-13.1.5.tgz",
+      "integrity": "sha512-X/5sAEiWXL2kdoGE3NO5KmbfcmaCWuWVZXHu8OQef7Yig4ZgHFkGD11HKJ5KqDrDg+SRZe4ISd6MxE7vGUgm4w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-status-bar": {
@@ -8812,19 +8867,6 @@
       "optionalDependencies": {
         "@google-cloud/firestore": "^7.11.0",
         "@google-cloud/storage": "^7.14.0"
-      }
-    },
-    "node_modules/firebase-admin/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/firebase-tools": {
@@ -10476,6 +10518,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -11920,6 +11971,18 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/merge-stream": {
@@ -16718,14 +16781,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "dev": true,
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/valid-url": {

--- a/package.json
+++ b/package.json
@@ -10,16 +10,20 @@
   },
   "dependencies": {
     "@expo-google-fonts/dm-sans": "^0.3.0",
+    "@react-native-async-storage/async-storage": "^1.24.0",
     "@react-native-community/datetimepicker": "8.3.0",
     "@react-navigation/bottom-tabs": "^7.3.14",
     "@react-navigation/native": "^7.1.9",
     "@react-navigation/native-stack": "^7.3.13",
+    "@types/uuid": "^10.0.0",
     "expo": "~53.0.9",
     "expo-constants": "^17.1.6",
     "expo-dev-client": "~5.2.0",
     "expo-font": "~13.3.1",
+    "expo-image-manipulator": "~13.1.7",
     "expo-image-picker": "~16.1.4",
     "expo-linear-gradient": "~14.1.4",
+    "expo-sharing": "~13.1.5",
     "expo-status-bar": "~2.2.3",
     "expo-updates": "~0.28.13",
     "firebase": "^11.8.1",
@@ -31,8 +35,7 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-svg": "15.11.2",
-    "expo-sharing": "~13.1.5",
-    "expo-image-manipulator": "~13.1.7"
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,104 @@
+import React, { createContext, useState, useEffect, ReactNode } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { v4 as uuidv4 } from 'uuid';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { db } from '../../firebaseConfig';
+
+// Define User type
+export interface User {
+  uid: string;
+  name?: string;
+  photoUrl?: string;
+}
+
+// Define AuthContext type
+export interface AuthContextType {
+  user: User | null;
+  setProfile: (name: string, photoUrl?: string) => Promise<void>;
+}
+
+// Create AuthContext
+export const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+// AuthProvider component
+interface AuthProviderProps {
+  children: ReactNode;
+}
+
+export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    initializeUser();
+  }, []);
+
+  const initializeUser = async () => {
+    try {
+      // Read UID from AsyncStorage or generate a new one
+      let uid = await AsyncStorage.getItem('uid');
+      
+      if (!uid) {
+        uid = uuidv4();
+        await AsyncStorage.setItem('uid', uid);
+      }
+
+      // Fetch user data from Firestore
+      const userDocRef = doc(db, 'users', uid);
+      const userDocSnap = await getDoc(userDocRef);
+
+      if (userDocSnap.exists()) {
+        // User exists in Firestore, merge data into state
+        const userData = userDocSnap.data() as Omit<User, 'uid'>;
+        setUser({
+          uid,
+          ...userData,
+        });
+      } else {
+        // User doesn't exist in Firestore, set basic user with UID
+        setUser({ uid });
+      }
+    } catch (error) {
+      console.error('Error initializing user:', error);
+      // Fallback: create user with generated UID
+      const fallbackUid = uuidv4();
+      setUser({ uid: fallbackUid });
+    }
+  };
+
+  const setProfile = async (name: string, photoUrl?: string) => {
+    if (!user) {
+      throw new Error('No user found');
+    }
+
+    try {
+      const profileData: Partial<User> = { name };
+      if (photoUrl) {
+        profileData.photoUrl = photoUrl;
+      }
+
+      // Write to Firestore (merge with existing data)
+      const userDocRef = doc(db, 'users', user.uid);
+      await setDoc(userDocRef, profileData, { merge: true });
+
+      // Update context state
+      setUser(prevUser => ({
+        ...prevUser!,
+        ...profileData,
+      }));
+    } catch (error) {
+      console.error('Error updating profile:', error);
+      throw error;
+    }
+  };
+
+  const contextValue: AuthContextType = {
+    user,
+    setProfile,
+  };
+
+  return (
+    <AuthContext.Provider value={contextValue}>
+      {children}
+    </AuthContext.Provider>
+  );
+}; 


### PR DESCRIPTION
Description

Introduces AuthContext in src/context/AuthContext.tsx

Generates/persists a UUID in AsyncStorage on first launch

Reads and writes user profile data to Firestore users/{uid}

Exposes user and setProfile(name, photoUrl?) via React Context

Wraps the app in <AuthProvider> in App.tsx

Adds dependencies:

@react-native-async-storage/async-storage

uuid and @types/uuid

Testing Steps

Launch the app and verify a UID is displayed (newly generated).

Close and reopen the app—confirm the same UID persists.

Call setProfile('Alice', 'https://…') in a test screen and verify the Firestore document users/{uid} is created/updated.